### PR TITLE
Syncs dataSilo.notifyEmailAddress

### DIFF
--- a/examples/promptAPerson.yml
+++ b/examples/promptAPerson.yml
@@ -1,5 +1,5 @@
 data-silos:
-  - title: Manually Notification
+  - title: Manually Notify Backend Team
     description: Notify backend team to delete data
     integrationName: promptAPerson
     notify-email-address: test@transcend.io
@@ -8,7 +8,6 @@ data-silos:
         key: _global
         privacy-actions:
           - ERASURE
-          - ACCESS
       - title: File Upload
         description: Use data dump for backend service
         key: upload

--- a/examples/promptAPerson.yml
+++ b/examples/promptAPerson.yml
@@ -1,0 +1,16 @@
+data-silos:
+  - title: Manually Notification
+    description: Notify backend team to delete data
+    integrationName: promptAPerson
+    notify-email-address: test@transcend.io
+    datapoints:
+      - title: Prompt Manual Entry
+        key: _global
+        privacy-actions:
+          - ERASURE
+          - ACCESS
+      - title: File Upload
+        description: Use data dump for backend service
+        key: upload
+        privacy-actions:
+          - ACCESS

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/schema-sync",
   "description": "Small package containing useful typescript utilities.",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "homepage": "https://github.com/transcend-io/schema-sync",
   "repository": {
     "type": "git",

--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -163,6 +163,8 @@ export const DataSiloInput = t.intersection([
     description: t.string,
     /** The webhook URL to notify for data privacy requests */
     url: t.string,
+    /** The email address of the user to notify when a promptAPerson integration */
+    'notify-email-address': t.string,
     /** The title of the API key that will be used to respond to privacy requests */
     'api-key-title': t.string,
     /**

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -140,6 +140,7 @@ export const DATA_SILO = gql`
       description
       type
       url
+      notifyEmailAddress
       apiKeys {
         title
       }
@@ -200,6 +201,7 @@ export const UPDATE_DATA_SILO = gql`
     $title: String
     $description: String
     $url: String
+    $notifyEmailAddress: String
     $identifiers: [String!]
     $isLive: Boolean
     $dataSubjectBlockListIds: [ID!]
@@ -213,6 +215,7 @@ export const UPDATE_DATA_SILO = gql`
         title: $title
         description: $description
         url: $url
+        notifyEmailAddress: $notifyEmailAddress
         identifiers: $identifiers
         isLive: $isLive
         dataSubjectBlockListIds: $dataSubjectBlockListIds

--- a/src/syncDataSilos.ts
+++ b/src/syncDataSilos.ts
@@ -174,6 +174,8 @@ export interface DataSiloEnriched {
   description: string;
   /** Webhook URL */
   url?: string;
+  /** Email address of user to notify for prompt a person use case */
+  notifyEmailAddress?: string;
   /** Associated API keys */
   apiKeys: {
     /** Title */
@@ -269,6 +271,9 @@ export async function syncDataSilo(
       identifiers: dataSilo['identity-keys'],
       isLive: !dataSilo.disabled,
       ownerEmails: dataSilo.owners,
+      ...(dataSilo['notify-email-address']
+        ? { notifyEmailAddress: dataSilo['notify-email-address'] }
+        : {}),
       // clear out if not specified, otherwise the update needs to be applied after
       // all data silos are created
       dependedOnDataSiloTitles: dataSilo['deletion-dependencies']

--- a/src/syncDataSilos.ts
+++ b/src/syncDataSilos.ts
@@ -271,9 +271,7 @@ export async function syncDataSilo(
       identifiers: dataSilo['identity-keys'],
       isLive: !dataSilo.disabled,
       ownerEmails: dataSilo.owners,
-      ...(dataSilo['notify-email-address']
-        ? { notifyEmailAddress: dataSilo['notify-email-address'] }
-        : {}),
+      notifyEmailAddress: dataSilo['notify-email-address'],
       // clear out if not specified, otherwise the update needs to be applied after
       // all data silos are created
       dependedOnDataSiloTitles: dataSilo['deletion-dependencies']


### PR DESCRIPTION
- closes https://transcend.height.app/T-13327

Added the ability to specify `notify-email-address` for a data silo, and that will configure email notifications for that data silo.