### PR TITLE
Create new silo handles notifyEmailAddress

### DIFF
--- a/examples/promptAPerson.yml
+++ b/examples/promptAPerson.yml
@@ -2,7 +2,7 @@ data-silos:
   - title: Manually Notify Backend Team
     description: Notify backend team to delete data
     integrationName: promptAPerson
-    notify-email-address: test@transcend.io
+    notify-email-address: test+2@transcend.io
     datapoints:
       - title: Prompt Manual Entry
         key: _global

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/schema-sync",
   "description": "Small package containing useful typescript utilities.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "homepage": "https://github.com/transcend-io/schema-sync",
   "repository": {
     "type": "git",

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -127,6 +127,8 @@ export const DATA_SILOS = gql`
       nodes {
         id
         title
+        link
+        type
       }
     }
   }

--- a/src/gqls.ts
+++ b/src/gqls.ts
@@ -288,6 +288,7 @@ export const CREATE_DATA_SILO = gql`
     $type: String!
     $identifiers: [String!]
     $isLive: Boolean!
+    $notifyEmailAddress: String
     $dataSubjectBlockListIds: [ID!]
     $dependedOnDataSiloTitles: [String!]
     $ownerEmails: [String!]
@@ -299,6 +300,7 @@ export const CREATE_DATA_SILO = gql`
         title: $title
         description: $description
         url: $url
+        notifyEmailAddress: $notifyEmailAddress
         identifiers: $identifiers
         isLive: $isLive
         dataSubjectBlockListIds: $dataSubjectBlockListIds

--- a/src/syncConfigurationToTranscend.ts
+++ b/src/syncConfigurationToTranscend.ts
@@ -72,7 +72,9 @@ export async function syncConfigurationToTranscend(
           apiKeyTitleMap,
         );
         logger.info(
-          colors.green(`Successfully synced data silo "${dataSilo.title}"!`),
+          colors.green(
+            `Successfully synced data silo "${dataSilo.title}"! View at: ${dataSiloInfo.link}`,
+          ),
         );
 
         // Queue up dependency update

--- a/src/syncDataSilos.ts
+++ b/src/syncDataSilos.ts
@@ -30,6 +30,8 @@ export interface DataSilo {
   title: string;
   /** Type of silo */
   type: string;
+  /** The link to the data silo */
+  link: string;
 }
 
 const PAGE_SIZE = 20;

--- a/src/syncDataSilos.ts
+++ b/src/syncDataSilos.ts
@@ -302,6 +302,7 @@ export async function syncDataSilo(
       identifiers: dataSilo['identity-keys'],
       isLive: !dataSilo.disabled,
       ownerEmails: dataSilo.owners,
+      notifyEmailAddress: dataSilo['notify-email-address'],
       // clear out if not specified, otherwise the update needs to be applied after
       // all data silos are created
       dependedOnDataSiloTitles: dataSilo['deletion-dependencies']


### PR DESCRIPTION
Was possible to update a data silo with notifyEmailAddress, but was not working for newly created.